### PR TITLE
chore(Plugins): Fixing raknet builds

### DIFF
--- a/Source/Plugins/FileList.cpp
+++ b/Source/Plugins/FileList.cpp
@@ -265,7 +265,7 @@ void FileList::AddFilesFromDirectory(const char *applicationDirectory, const cha
         strcat(fullPath, "*");
 
 
-        intptr_t dir = _findfirst(fullPath, &fileInfo);
+        long dir = _findfirst(fullPath, &fileInfo);
         if (dir == -1)
         {
             _findclose(dir);
@@ -282,11 +282,8 @@ void FileList::AddFilesFromDirectory(const char *applicationDirectory, const cha
         do
         {
             // no guarantee these entries are first...
-            if (strcmp(".", fileInfo.name) == 0 ||
-                strcmp("..", fileInfo.name) == 0)
-            {
+            if (strcmp(".", fileInfo.name) == 0 || strcmp("..", fileInfo.name) == 0)
                 continue;
-            }
 
             if ((fileInfo.attrib & (_A_HIDDEN | _A_SUBDIR | _A_SYSTEM)) == 0)
             {

--- a/Source/Utils/FileOperations.cpp
+++ b/Source/Utils/FileOperations.cpp
@@ -121,7 +121,7 @@ bool DirectoryExists(const char *directory)
     strcpy(baseDirWithStars, directory);
     AddSlash(baseDirWithStars);
     strcat(baseDirWithStars, "*.*");
-    intptr_t dir = _findfirst(baseDirWithStars, &fileInfo);
+    long dir = _findfirst(baseDirWithStars, &fileInfo);
     if (dir == -1)
         return false;
     _findclose(dir);

--- a/Source/Utils/_FindFirst.cpp
+++ b/Source/Utils/_FindFirst.cpp
@@ -7,6 +7,8 @@
 #include "_FindFirst.h"
 #include "DS_List.h"
 
+#include "FileList.h"
+
 #include <sys/stat.h>
 
 #include <fnmatch.h>
@@ -57,11 +59,11 @@ long _findfirst(const char *name, _finddata_t *f)
     // being '.'
     if (_findnext(ret, f) == -1)
         return -1;
-    else
-        return ret;
+    
+    return ret;
 }
 
-int _findnext(intptr_t h, _finddata_t *f)
+int _findnext(long h, _finddata_t *f)
 {
     RakAssert(h >= 0 && h < (long) fileInfo.Size());
     if (h < 0 || h >= (long) fileInfo.Size()) return -1;

--- a/Source/Utils/_FindFirst.h
+++ b/Source/Utils/_FindFirst.h
@@ -47,7 +47,7 @@ typedef struct _findinfo_t
 } _findinfo;
 
 long _findfirst(const char *name, _finddata_t *f);
-int _findnext(intptr_t h, _finddata_t *f);
+int _findnext(long h, _finddata_t *f);
 int _findclose(intptr_t h);
 
 #endif


### PR DESCRIPTION
1. Cleanup of monster method in httpconnection
2. Correcting type declarations in headers and functions, directly repairing the raknet build process
3. Small guard clause change due to failed return type.
